### PR TITLE
Fetch Model Information

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -38,7 +38,7 @@ function setupIpcMain() {
     // DatabaseConn.resetDatabase(getDbPath(app)),
     DatabaseConn.resetDummyData(getDbPath(app)),
   );
-  // Registration: handles registering models
+  // Registration: handles registering model servers
   ipcMain.handle(
     'register:register-model-app-ip',
     registration.registerModelAppIp,
@@ -52,6 +52,7 @@ function setupIpcMain() {
     registration.getModelAppStatus,
   );
   ipcMain.handle('register:get-model-servers', registration.getModelServers);
+  ipcMain.handle('register:get-model-info', registration.getModelInfo);
 
   // Models: handles registering models
   ipcMain.handle('models:get-models', models.getModels);

--- a/src/main/model-apps/config.ts
+++ b/src/main/model-apps/config.ts
@@ -13,7 +13,7 @@ export type ModelAppConfig = {
 };
 
 export const SuperResolutionImageModel: ModelAppConfig = {
-  uid: 'model-super-res',
+  uid: 'model1',
   name: 'Image Super Resolution',
   version: '1.0.0',
   author: 'John Doe',
@@ -22,7 +22,7 @@ export const SuperResolutionImageModel: ModelAppConfig = {
 };
 
 export const TenSecondModel: ModelAppConfig = {
-  uid: 'model1',
+  uid: 'dummy-1',
   name: 'Ten Second Model',
   version: '0.8.5',
   author: 'Jane Smith',

--- a/src/main/model-apps/inference-service.ts
+++ b/src/main/model-apps/inference-service.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+import { ModelInfo } from 'src/shared/models';
 import { Inputs, Outputs, Parameters } from '../models/job';
 
 type ModelServerInfo = {
@@ -35,6 +36,7 @@ export default interface InferenceService {
     args: InferenceArgs,
     signal: AbortSignal,
   ): Promise<SuccessResponse | ErrorResponse>;
+  fetchModelInfo(server: ModelServerInfo): Promise<ModelInfo | null>;
 }
 
 export { InferenceArgs, ModelServerInfo };

--- a/src/main/model-apps/inference-task.ts
+++ b/src/main/model-apps/inference-task.ts
@@ -1,4 +1,5 @@
 import log from 'electron-log';
+import { ModelInfo } from 'src/shared/models';
 import InferenceService, {
   InferenceArgs,
   SuccessResponse,
@@ -35,6 +36,12 @@ class InferenceTask {
 
   public async pingHealth(server: ModelServerInfo): Promise<boolean> {
     return this.service.pingHealth(server);
+  }
+
+  public async fetchModelInfo(
+    server: ModelServerInfo,
+  ): Promise<ModelInfo | null> {
+    return this.service.fetchModelInfo(server);
   }
 }
 

--- a/src/main/model-apps/super-res/super-res-inference-service.ts
+++ b/src/main/model-apps/super-res/super-res-inference-service.ts
@@ -1,5 +1,6 @@
 /* eslint-disable class-methods-use-this */
 // import log from 'electron-log';
+import { ModelInfo } from 'src/shared/models';
 import InferenceService, {
   ErrorResponse,
   InferenceArgs,
@@ -9,12 +10,14 @@ import InferenceService, {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SERVER_HEALTH_SLUG = '/health';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const MODEL_APP_INFO_SLUG = '/info';
 
 class SuperResInferenceService implements InferenceService {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  pingHealth(_server: ModelServerInfo): Promise<boolean> {
+  pingHealth(server: ModelServerInfo): Promise<boolean> {
     // return fetch(
-    //   `http://${model.serverAddress}:${model.serverPort}${SERVER_HEALTH_SLUG}`,
+    //   `http://${server.serverAddress}:${server.serverPort}${SERVER_HEALTH_SLUG}`,
     // )
     //   .then((res) => res.status)
     //   .then((status) => {
@@ -76,6 +79,64 @@ class SuperResInferenceService implements InferenceService {
         );
       }, 1000);
     });
+  }
+
+  public async fetchModelInfo(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    server: ModelServerInfo,
+  ): Promise<ModelInfo | null> {
+    // return fetch(
+    //   `http://${server.serverAddress}:${server.serverPort}${MODEL_APP_INFO_SLUG}`,
+    // )
+    //   .then((res) => {
+    //     if (res.status !== 200) {
+    //       log.error(`Failed to fetch model info: ${res.statusText}`);
+    //       return null;
+    //     }
+    //     return res.json() as Promise<ModelInfo>;
+    //   })
+    //   .catch((error) => {
+    //     log.error(`Failed to fetch model info: ${error}`);
+    //     return null;
+    // });
+    return {
+      uid: 'model1',
+      name: 'Image Super Resolution',
+      version: '1.0.0',
+      author: 'John Doe',
+      lastUpdated: new Date('2023-10-01T12:00:00Z'),
+      description: 'This model upscales images to a higher resolution.',
+      parameters: [
+        {
+          name: 'Scale',
+          type: 'Number',
+          description:
+            'The factor by which to upscale the image (between 1 and 4).',
+        },
+      ],
+      inputTypes: [
+        {
+          type: 'Image(s)',
+          description: 'The images to be upscaled.',
+        },
+      ],
+      outputTypes: [
+        {
+          type: 'Image(s)',
+          description: 'The upscaled images.',
+        },
+      ],
+      constraints: [
+        {
+          name: 'Minimum Scale',
+          description: 'The minimum scale factor is 1.',
+        },
+        {
+          name: 'Maximum Scale',
+          description: 'The maximum scale factor is 4.',
+        },
+      ],
+    } as ModelInfo;
   }
 }
 

--- a/src/main/model-apps/ten-second-model/ten-second-model-service.ts
+++ b/src/main/model-apps/ten-second-model/ten-second-model-service.ts
@@ -1,4 +1,5 @@
 /* eslint-disable class-methods-use-this */
+import { ModelInfo } from 'src/shared/models';
 import InferenceService, {
   ErrorResponse,
   InferenceArgs,
@@ -8,7 +9,7 @@ import InferenceService, {
 
 class TenSecondModelService implements InferenceService {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  pingHealth(_server: ModelServerInfo): Promise<boolean> {
+  pingHealth(server: ModelServerInfo): Promise<boolean> {
     // return fetch(
     //   `http://${model.serverAddress}:${model.serverPort}${SERVER_HEALTH_SLUG}`,
     // )
@@ -26,7 +27,6 @@ class TenSecondModelService implements InferenceService {
     });
   }
 
-  // eslint-disable-next-line class-methods-use-this
   public async runInference(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     args: InferenceArgs,
@@ -41,6 +41,29 @@ class TenSecondModelService implements InferenceService {
           }),
         );
       }, 10000);
+    });
+  }
+
+  public async fetchModelInfo(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    server: ModelServerInfo,
+  ): Promise<ModelInfo | null> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          uid: 'dummy-1',
+          name: 'Ten Second Model',
+          version: '0.8.5',
+          author: 'Jane Smith',
+          lastUpdated: new Date('2023-11-15T14:30:00Z'),
+          parameters: [
+            { name: 'param1', type: 'number', description: 'Parameter 1' },
+          ],
+          inputTypes: [{ type: 'image', description: 'Input image' }],
+          outputTypes: [{ type: 'image', description: 'Output image' }],
+          constraints: [{ name: 'constraint1', description: 'Constraint 1' }],
+        } as ModelInfo);
+      }, 2000);
     });
   }
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,8 +1,15 @@
 // Disable no-unused-vars, broken for spread args
 /* eslint no-unused-vars: off */
 import { contextBridge, ipcRenderer } from 'electron';
-import { MLModel, ModelServer, Job, ModelAppStatus } from 'src/shared/models';
 import {
+  MLModel,
+  ModelServer,
+  Job,
+  ModelAppStatus,
+  ModelInfo,
+} from 'src/shared/models';
+import {
+  GetModelInfoArgs,
   GetModelAppStatusArgs,
   RegisterModelArgs,
   UnregisterModelArgs,
@@ -27,6 +34,11 @@ const registrationHandler = {
       'register:get-model-app-status',
       args,
     ) as Promise<ModelAppStatus>,
+  getModelInfo: (args: GetModelInfoArgs) =>
+    ipcRenderer.invoke(
+      'register:get-model-info',
+      args,
+    ) as Promise<ModelInfo | null>,
   getModelServers: () =>
     ipcRenderer.invoke('register:get-model-servers') as Promise<ModelServer[]>,
 };

--- a/src/renderer/ModelDetails.tsx
+++ b/src/renderer/ModelDetails.tsx
@@ -1,25 +1,34 @@
 import { Link, useParams } from 'react-router-dom';
 import { Button } from './components/ui/button';
-import { useMLModel } from './lib/hooks';
+import { useMLModel, useModelInfo } from './lib/hooks';
 import GreenRunIcon from './components/GreenRunIcon';
 
 function ModelDetails() {
   const { modelUid } = useParams();
 
-  const modelParameters = [
-    'Input size, default is 256x256',
-    'upscale factor, default is 2',
-  ];
-  const modelConstraints = [
-    "Only images with the '.jpg' or '.png' extension are supported",
-    'The input image must be a square image',
-    'The input images must be smaller than 1024x1024',
-  ];
+  const {
+    data: model,
+    isLoading: modelIsLoading,
+    error: errorModel,
+  } = useMLModel(modelUid);
 
-  const { data: model, isLoading, error } = useMLModel(modelUid);
-  if (isLoading) return <div>loading model..</div>;
-  if (error) return <div>failed to load model. Error: {error.toString()}</div>;
+  const {
+    modelInfo,
+    isLoading: modelInfoIsLoading,
+    error: errorModelInfo,
+  } = useModelInfo(modelUid);
+
+  if (modelIsLoading) return <div>loading model..</div>;
+  if (errorModel)
+    return <div>failed to load model. Error: {errorModel.toString()}</div>;
   if (!model) return <div>no model</div>;
+
+  if (modelInfoIsLoading) return <div>loading model info..</div>;
+  if (errorModelInfo)
+    return (
+      <div>failed to load model info. Error: {errorModelInfo.toString()}</div>
+    );
+  if (!modelInfo) return <div>no model info</div>;
 
   return (
     <div className="flex flex-row justify-between m-3">
@@ -28,41 +37,70 @@ function ModelDetails() {
           <h1 className="font-bold text-xl md:text-2xl lg:text-3xl">
             {model.name}
           </h1>
-          <p className="text-md lg:text-lg">{model.name} DESCRIPTION</p>
+          <p className="text-md lg:text-lg">{modelInfo.description}</p>
         </div>
-        <div className="felx flex-col gap-2">
+        <div className="flex flex-col gap-2">
           <h1 className="font-bold text-lg md:text-xl lg:text-2xl">
-            {' '}
             Input Type
           </h1>
-          <p className="text-md lg:text-lg">INPUTS</p>
-        </div>
-        <div className="felx flex-col gap-2">
-          <h1 className="font-bold text-lg md:text-xl lg:text-2xl">
-            {' '}
-            Output Type
-          </h1>
-          <p className="text-md lg:text-lg">OUTPUTS</p>
-        </div>
-        <div className="felx flex-col gap-2">
-          <h1 className="font-bold text-lg md:text-xl lg:text-2xl">
-            {' '}
-            Parameters
-          </h1>
-          <ul className="flex flex-col gap-[0.1rem] list-disc ml-4">
-            {modelParameters.map((parameter) => (
-              <li className="text-md lg:text-lg">{parameter}</li>
-            ))}
+          <ul className="text-md lg:text-lg list-disc ml-4">
+            {modelInfo.inputTypes.map(
+              (inputType: { type: string; description: string }) => {
+                return (
+                  <li key={inputType.type}>
+                    <strong>{inputType.type}:</strong> {inputType.description}
+                  </li>
+                );
+              },
+            )}
           </ul>
         </div>
-        <div className="felx flex-col gap-2">
+        <div className="flex flex-col gap-2">
+          <h1 className="font-bold text-lg md:text-xl lg:text-2xl">
+            Output Type
+          </h1>
+          <ul className="text-md lg:text-lg list-disc ml-4">
+            {modelInfo.outputTypes.map(
+              (outputType: { type: string; description: string }) => {
+                return (
+                  <li key={outputType.type}>
+                    <strong>{outputType.type}:</strong> {outputType.description}
+                  </li>
+                );
+              },
+            )}
+          </ul>
+        </div>
+        <div className="flex flex-col gap-2">
+          <h1 className="font-bold text-lg md:text-xl lg:text-2xl">
+            Parameters
+          </h1>
+          <ul className="text-md lg:text-lg list-disc ml-4">
+            {modelInfo.parameters.map(
+              (param: { name: string; type: string; description: string }) => {
+                return (
+                  <li key={param.type}>
+                    <strong>{param.name}:</strong> {param.description}
+                  </li>
+                );
+              },
+            )}
+          </ul>
+        </div>
+        <div className="flex flex-col gap-2">
           <h1 className="font-bold text-lg md:text-xl lg:text-2xl">
             Constraints
           </h1>
-          <ul className="flex flex-col gap-[0.1rem] list-disc ml-4">
-            {modelConstraints.map((constraint) => (
-              <li className="text-md lg:text-lg">{constraint}</li>
-            ))}
+          <ul className="text-md lg:text-lg list-disc ml-4">
+            {modelInfo.constraints.map(
+              (constraint: { name: string; description: string }) => {
+                return (
+                  <li key={constraint.name}>
+                    <strong>{constraint.name}:</strong> {constraint.description}
+                  </li>
+                );
+              },
+            )}
           </ul>
         </div>
       </div>
@@ -70,15 +108,17 @@ function ModelDetails() {
         <h1 className="font-bold text-lg md:text-xl lg:text-2xl m-2">
           Model Version
         </h1>
-        <p className="m-2">{model.version}</p>
+        <p className="m-2">{modelInfo.version}</p>
         <h1 className="font-bold text-lg md:text-xl lg:text-2xl m-2">
           Developed By
         </h1>
-        <p className="m-2">{model.author}</p>
+        <p className="m-2">{modelInfo.author}</p>
         <h1 className="font-bold text-lg md:text-xl lg:text-2xl m-2">
           Last Updated
         </h1>
-        <p className="m-2">{model.lastUpdated.toUTCString()}</p>
+        <p className="m-2">
+          {modelInfo.lastUpdated.toLocaleString('en-US', { timeZone: 'EST' })}
+        </p>
         <div className="mt-10">
           <Link to="/models/outputs">
             <Button className="w-full flex flex-row gap-2 hover:-translate-y-0.5 transition-all py-2 px-6 rounded-lg bg-green-600 hover:bg-green-500">

--- a/src/renderer/lib/hooks.ts
+++ b/src/renderer/lib/hooks.ts
@@ -83,6 +83,26 @@ export function useServers() {
   };
 }
 
+export function useModelInfo(modelUid?: string) {
+  const fetcher = () =>
+    window.registration.getModelInfo({
+      modelUid: modelUid!,
+    });
+
+  const { data, error, isLoading, isValidating, mutate } = useSWR(
+    !modelUid ? null : `register:get-model-info-${modelUid}`,
+    fetcher,
+  );
+
+  return {
+    modelInfo: data,
+    error,
+    isLoading,
+    isValidating,
+    mutate,
+  };
+}
+
 export function useMLModels() {
   const fetcher = () => window.models.getModels();
   const { data, error, isLoading, isValidating, mutate } = useSWR(

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -15,3 +15,16 @@ export enum ModelAppStatus {
   Error = 'Error',
   Unregistered = 'Unregistered',
 }
+
+export type ModelInfo = {
+  uid: string;
+  name: string;
+  version: string;
+  author: string;
+  lastUpdated: Date;
+  description: string;
+  parameters: { name: string; type: string; description: string }[];
+  inputTypes: { type: string; description: string }[];
+  outputTypes: { type: string; description: string }[];
+  constraints: { name: string; description: string }[];
+};


### PR DESCRIPTION
Closes #128.

Note: I'm not sure I like the way I'm handling errors with `fetchModelInfo` by setting the return type to `Promise<ModelInfo | null>` (check out `super-res-inference-service.ts` for example). Let me know if there's a better way to go about it. I was thinking of reusing the SuccessResponse/ErrorResponse classes but their data fields are of type `object`, which isn't restrictive enough compared to the `ModelInfo` type.

![image](https://github.com/user-attachments/assets/1e012f7a-7472-4140-a91a-c64146640a52)