### PR TITLE
Add unique key to children and fix scrolling in Jobs page

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -108,8 +108,6 @@ const installExtensions = async () => {
     .catch(console.log);
 };
 
-// remoteMain.initialize();
-
 /**
  * Window Management ...
  */
@@ -146,7 +144,6 @@ const createWindow = async () => {
       preload: app.isPackaged
         ? path.join(__dirname, 'preload.js')
         : path.join(__dirname, '../../.erb/dll/preload.js'),
-      // plugins: true,
     },
   });
 
@@ -175,9 +172,6 @@ const createWindow = async () => {
     shell.openExternal(edata.url);
     return { action: 'deny' };
   });
-
-  // To enable remote main -> selecting folders
-  // remoteMain.enable(mainWindow.webContents);
 
   // Remove this if your app does not use auto updates
   // eslint-disable-next-line

--- a/src/renderer/JobViewDetails.tsx
+++ b/src/renderer/JobViewDetails.tsx
@@ -41,7 +41,11 @@ function JobViewDetails() {
           <h1 className="font-bold my-4">Inputs</h1>
           <div className="flex flex-col gap-2">
             {job.inputs.map((input) => (
-              <FilePathField path={input.path} label={input.path_key} />
+              <FilePathField
+                path={input.path}
+                label={input.path_key}
+                key={input.path}
+              />
             ))}
           </div>
         </div>
@@ -49,7 +53,11 @@ function JobViewDetails() {
           <h1 className="font-bold my-4">Output</h1>
           <div className="flex flex-col gap-2">
             {job.outputs.map((output) => (
-              <FilePathField path={output.path} label={output.path_key} />
+              <FilePathField
+                path={output.path}
+                label={output.path_key}
+                key={output.path}
+              />
             ))}
           </div>
         </div>

--- a/src/renderer/Jobs.tsx
+++ b/src/renderer/Jobs.tsx
@@ -152,7 +152,7 @@ function Jobs() {
         </div>
       </div>
 
-      <div className="mx-3 mt-6">
+      <div className="mx-3 my-6">
         <h1 className="font-bold text-xl md:text-2xl lg:text-4xl mb-4">
           Completed Jobs
           {jobsIsLoading && modelsIsLoading && (


### PR DESCRIPTION
Two minor fixes:
- `Warning: Each child in a list should have a unique "key" prop.` when navigating to View Job Details page.
- Can't scroll to the bottom of the Jobs page.