### PR TITLE
Fix shadcn namespacing

### DIFF
--- a/.erb/configs/webpack.config.base.ts
+++ b/.erb/configs/webpack.config.base.ts
@@ -47,7 +47,13 @@ const configuration: webpack.Configuration = {
     extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
     modules: [webpackPaths.srcPath, 'node_modules'],
     alias: {
-      '@shadcn': resolve(webpackPaths.rootPath, 'src', 'renderer'),
+      '@shadcn': resolve(
+        webpackPaths.rootPath,
+        'src',
+        'renderer',
+        'components',
+        'ui',
+      ),
     },
     // There is no need to add aliases here, the paths in tsconfig get mirrored
     plugins: [new TsconfigPathsPlugins()],

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/.erb/mocks/fileMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy",
-      "^@shadcn/(.*)$": "<rootDir>/src/renderer/$1",
+      "^@shadcn/(.*)$": "<rootDir>/src/renderer/components/ui/$1",
       "react-markdown": "<rootDir>/src/__mocks__/ReactMarkdownMock.tsx",
       "remark-gfm": "<rootDir>/src/__mocks__/RemarkGfmMock.ts"
     },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -21,13 +21,13 @@ import ModelRun from './models/ModelRun';
 import JobViewLayout from './jobs/JobViewLayout';
 import JobViewDetails from './jobs/JobViewDetails';
 import JobViewOutputs from './jobs/JobViewOutputs';
-import { ImageTitleNavBar, NavBarItem } from './NavBarItem';
 import FallbackError from './components/FallbackError';
 import RegistrationIcon from './components/icons/RegistrationIcon';
 import LogsIcon from './components/icons/LogsIcon';
 import AuditLogs from './audit_logs/AuditLogs';
 import ModelRunTask from './models/ModelRunTask';
 import ModelAppConnect from './registration/ModelAppConnect';
+import { NavBarItem, ImageTitleNavBar } from './navigation/NavBarItem';
 
 function RootLayout() {
   const navigate = useNavigate();

--- a/src/renderer/components/LoadingScreen.tsx
+++ b/src/renderer/components/LoadingScreen.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 import LoadingIcon from './icons/LoadingIcon';
 
 // eslint-disable-next-line react/require-default-props

--- a/src/renderer/components/icons/CancelIcon.tsx
+++ b/src/renderer/components/icons/CancelIcon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 // eslint-disable-next-line react/require-default-props
 function CancelIcon({ className = '' }: { className?: string }) {

--- a/src/renderer/components/icons/ConnectIcon.tsx
+++ b/src/renderer/components/icons/ConnectIcon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 // eslint-disable-next-line react/require-default-props
 function ConnectIcon({ className = '' }: { className?: string }) {

--- a/src/renderer/components/icons/DeleteIcon.tsx
+++ b/src/renderer/components/icons/DeleteIcon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 // eslint-disable-next-line react/require-default-props
 function DeleteIcon({ className = '' }: { className?: string }) {

--- a/src/renderer/components/icons/ExportIcon.tsx
+++ b/src/renderer/components/icons/ExportIcon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 export default function ExportIcon({
   className = '',

--- a/src/renderer/components/icons/LoadingIcon.tsx
+++ b/src/renderer/components/icons/LoadingIcon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 // eslint-disable-next-line react/require-default-props
 function LoadingIcon({ className = '' }: { className?: string }) {

--- a/src/renderer/components/icons/RegistrationIcon.tsx
+++ b/src/renderer/components/icons/RegistrationIcon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 export default function RegistrationIcon({
   className = '',

--- a/src/renderer/components/ui/accordion.tsx
+++ b/src/renderer/components/ui/accordion.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const Accordion = AccordionPrimitive.Root;
 

--- a/src/renderer/components/ui/button.tsx
+++ b/src/renderer/components/ui/button.tsx
@@ -4,8 +4,7 @@
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
-
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-600 disabled:pointer-events-none disabled:opacity-50',

--- a/src/renderer/components/ui/dialog.tsx
+++ b/src/renderer/components/ui/dialog.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Cross2Icon } from '@radix-ui/react-icons';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const Dialog = DialogPrimitive.Root;
 

--- a/src/renderer/components/ui/input.tsx
+++ b/src/renderer/components/ui/input.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/src/renderer/components/ui/label.tsx
+++ b/src/renderer/components/ui/label.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const labelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',

--- a/src/renderer/components/ui/navigation-menu.tsx
+++ b/src/renderer/components/ui/navigation-menu.tsx
@@ -7,7 +7,7 @@ import { ChevronDownIcon } from '@radix-ui/react-icons';
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';
 import { cva } from 'class-variance-authority';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,

--- a/src/renderer/components/ui/select.tsx
+++ b/src/renderer/components/ui/select.tsx
@@ -10,7 +10,7 @@ import {
 } from '@radix-ui/react-icons';
 import * as SelectPrimitive from '@radix-ui/react-select';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const Select = SelectPrimitive.Root;
 

--- a/src/renderer/components/ui/slider.tsx
+++ b/src/renderer/components/ui/slider.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,

--- a/src/renderer/components/ui/table.tsx
+++ b/src/renderer/components/ui/table.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const Table = React.forwardRef<
   HTMLTableElement,

--- a/src/renderer/components/ui/textarea.tsx
+++ b/src/renderer/components/ui/textarea.tsx
@@ -3,7 +3,7 @@
 
 'use client';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 import * as React from 'react';
 
 export interface TextareaProps

--- a/src/renderer/components/ui/tooltip.tsx
+++ b/src/renderer/components/ui/tooltip.tsx
@@ -6,7 +6,7 @@
 import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
-import { cn } from '@shadcn/lib/utils';
+import { cn } from 'src/renderer/lib/utils';
 
 const TooltipProvider = TooltipPrimitive.Provider;
 

--- a/src/renderer/jobs/JobViewDetails.tsx
+++ b/src/renderer/jobs/JobViewDetails.tsx
@@ -6,10 +6,10 @@ import {
   DialogTrigger,
   DialogFooter,
   DialogHeader,
-} from '@shadcn/components/ui/dialog';
-import InputField from '@shadcn/components/InputField';
-import { extractValuesFromRequestBodyInput } from '@shadcn/lib/utils';
-import ParameterField from '@shadcn/components/ParameterField';
+} from '@shadcn/dialog';
+import InputField from 'src/renderer/components/InputField';
+import { extractValuesFromRequestBodyInput } from 'src/renderer/lib/utils';
+import ParameterField from 'src/renderer/components/ParameterField';
 import { Button } from '../components/ui/button';
 import { useJob, useMLModel, useTask } from '../lib/hooks';
 import LoadingScreen from '../components/LoadingScreen';

--- a/src/renderer/jobs/JobViewOutputs.tsx
+++ b/src/renderer/jobs/JobViewOutputs.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import PreviewModal from '@shadcn/components/PreviewModal';
+import PreviewModal from 'src/renderer/components/PreviewModal';
 import videoResponse from 'src/shared/dummy_data/file_response_video';
 import { useJob } from '../lib/hooks';
 

--- a/src/renderer/jobs/Jobs.tsx
+++ b/src/renderer/jobs/Jobs.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Tooltip, TooltipProvider } from '@radix-ui/react-tooltip';
-import LoadingScreen from '@shadcn/components/LoadingScreen';
+import LoadingScreen from 'src/renderer/components/LoadingScreen';
 import {
   Table,
   TableBody,

--- a/src/renderer/jobs/sub-components/StatusComponent.tsx
+++ b/src/renderer/jobs/sub-components/StatusComponent.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@shadcn/components/ui/button';
+import { Button } from '@shadcn/button';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { useNavigate } from 'react-router-dom';
-import LoadingIcon from '@shadcn/components/icons/LoadingIcon';
+import LoadingIcon from 'src/renderer/components/icons/LoadingIcon';
 import CompletedIcon from '../../components/icons/CompletedIcon';
 import FailedIcon from '../../components/icons/FailedIcon';
 import CanceledIcon from '../../components/icons/CanceledIcon';

--- a/src/renderer/models/ModelDetails.tsx
+++ b/src/renderer/models/ModelDetails.tsx
@@ -1,11 +1,11 @@
 import { Link, useParams } from 'react-router-dom';
-import { useModelInfo, useServerStatus } from '@shadcn/lib/hooks';
-import LoadingScreen from '@shadcn/components/LoadingScreen';
+import LoadingScreen from 'src/renderer/components/LoadingScreen';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ModelAppStatus } from 'src/shared/models';
 import { Button } from '../components/ui/button';
 import GreenRunIcon from '../components/icons/GreenRunIcon';
+import { useModelInfo, useServerStatus } from '../lib/hooks';
 
 function ModelDetails() {
   const { modelUid } = useParams();

--- a/src/renderer/models/ModelRun.tsx
+++ b/src/renderer/models/ModelRun.tsx
@@ -1,7 +1,7 @@
-import LoadingScreen from '@shadcn/components/LoadingScreen';
-import { useApiRoutes, useMLModel } from '@shadcn/lib/hooks';
-import { cn } from '@shadcn/lib/utils';
+import LoadingScreen from 'src/renderer/components/LoadingScreen';
+import { cn } from 'src/renderer/lib/utils';
 import { NavLink, Outlet, useParams } from 'react-router-dom';
+import { useApiRoutes, useMLModel } from '../lib/hooks';
 
 function ModelRun() {
   const { modelUid } = useParams();

--- a/src/renderer/models/ModelRunTask.tsx
+++ b/src/renderer/models/ModelRunTask.tsx
@@ -1,10 +1,8 @@
-import GreenRunIcon from '@shadcn/components/icons/GreenRunIcon';
-import LoadingIcon from '@shadcn/components/icons/LoadingIcon';
-import InputField from '@shadcn/components/InputField';
-import ParameterField from '@shadcn/components/ParameterField';
-import { Button } from '@shadcn/components/ui/button';
-import { useTaskSchema } from '@shadcn/lib/hooks';
-import { buildRequestBody } from '@shadcn/lib/utils';
+import GreenRunIcon from 'src/renderer/components/icons/GreenRunIcon';
+import LoadingIcon from 'src/renderer/components/icons/LoadingIcon';
+import InputField from 'src/renderer/components/InputField';
+import ParameterField from 'src/renderer/components/ParameterField';
+import { Button } from '@shadcn/button';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import {
@@ -13,6 +11,8 @@ import {
   SchemaAPIRoute,
 } from 'src/shared/generated_models';
 import { RunJobArgs } from 'src/shared/models';
+import { useTaskSchema } from '../lib/hooks';
+import { buildRequestBody } from '../lib/utils';
 
 export default function ModelRunTask() {
   const { modelUid, order } = useParams();

--- a/src/renderer/models/Models.tsx
+++ b/src/renderer/models/Models.tsx
@@ -1,4 +1,4 @@
-import RegisterModelButton from '@shadcn/components/RegisterModelButton';
+import RegisterModelButton from 'src/renderer/components/RegisterModelButton';
 import { useMLModels, useServers, useServerStatuses } from '../lib/hooks';
 import LoadingIcon from '../components/icons/LoadingIcon';
 import LoadingScreen from '../components/LoadingScreen';

--- a/src/renderer/models/ModelsTable.tsx
+++ b/src/renderer/models/ModelsTable.tsx
@@ -4,7 +4,7 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
-} from '@shadcn/components/ui/tooltip';
+} from '@shadcn/tooltip';
 import { MLModel, ModelAppStatus } from 'src/shared/models';
 import {
   Table,

--- a/src/renderer/navigation/NavBarItem.tsx
+++ b/src/renderer/navigation/NavBarItem.tsx
@@ -1,6 +1,6 @@
 import { NavLink } from 'react-router-dom';
 import React, { ReactNode } from 'react';
-import { cn } from './lib/utils';
+import { cn } from '../lib/utils';
 
 export function RegularTitleNavBar({
   path,

--- a/src/renderer/registration/RegistrationTable.tsx
+++ b/src/renderer/registration/RegistrationTable.tsx
@@ -5,9 +5,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@shadcn/components/ui/table';
+} from '@shadcn/table';
 import { MLModel } from 'src/shared/models';
-import RegisterModelButton from '@shadcn/components/RegisterModelButton';
+import RegisterModelButton from 'src/renderer/components/RegisterModelButton';
 import { useMLModels, useServers } from '../lib/hooks';
 import { createMLServerMap } from '../lib/utils';
 import ModelStatusIndicator from '../models/ModelStatusIndicator';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "outDir": ".erb/dll",
     "baseUrl": ".",
     "paths": {
-      "@shadcn/*": ["./src/renderer/*"]
+      "@shadcn/*": ["./src/renderer/components/ui/*"]
     },
     "skipLibCheck": true
   },


### PR DESCRIPTION
Earlier, components defined by us (such as `InputField`) was imported as `import InputField from @shadcn/components/` which is incorrect because `InputField` is not a shadcn component.