### PR TITLE
Detect old flask-ml version

### DIFF
--- a/src/main/flask-ml/register-model-service.ts
+++ b/src/main/flask-ml/register-model-service.ts
@@ -84,6 +84,11 @@ export default class RegisterModelService {
 
     return fetch(`http://${serverAddress}:${serverPort}${APP_METADATA_SLUG}`)
       .then(async (res) => {
+        if (res.status === 404) {
+          throw new Error('404 App metadata route not found', {
+            cause: res.statusText,
+          });
+        }
         if (res.status !== 200) {
           throw new Error('Failed to fetch app metadata.');
         }
@@ -92,7 +97,7 @@ export default class RegisterModelService {
       .then((data: AppMetadata) => data)
       .catch((error) => {
         log.error('Failed to fetch app metadata', error);
-        throw new Error('Failed to fetch app metadata. Server may be offline.');
+        throw error;
       });
   }
 


### PR DESCRIPTION
Shows error in the UI as
```
Failed to connect to the server. Make sure the Flask-ML version installed on the server is ≥ 0.2.5 and that your server has app metadata added to it.
```
if `/api/app_metadata` was a 404

![image](https://github.com/user-attachments/assets/67f11c63-1468-401f-8fc0-0aab6fa74b76)
