### PR TITLE
Differentiate between old flask ml version and app metadata not set

### DIFF
--- a/src/main/flask-ml/register-model-service.ts
+++ b/src/main/flask-ml/register-model-service.ts
@@ -17,6 +17,8 @@ import TaskDb from '../models/tasks';
 const API_ROUTES_SLUG = '/api/routes';
 const APP_METADATA_SLUG = '/api/app_metadata';
 
+type ModelMetadataError = { error: 'App metadata not set' };
+
 export default class RegisterModelService {
   static async registerModel(serverAddress: string, serverPort: number) {
     const modelInfo = await RegisterModelService.getAppMetadata(
@@ -85,7 +87,7 @@ export default class RegisterModelService {
     return fetch(`http://${serverAddress}:${serverPort}${APP_METADATA_SLUG}`)
       .then(async (res) => {
         if (res.status === 404) {
-          throw new Error('404 App metadata route not found', {
+          throw new Error('404 APP_METADATA_SLUG not found on server', {
             cause: res.statusText,
           });
         }
@@ -94,7 +96,12 @@ export default class RegisterModelService {
         }
         return res.json();
       })
-      .then((data: AppMetadata) => data)
+      .then((data: AppMetadata | ModelMetadataError) => {
+        if ('error' in data) {
+          throw new Error('App metadata not set');
+        }
+        return data;
+      })
       .catch((error) => {
         log.error('Failed to fetch app metadata', error);
         throw error;

--- a/src/renderer/registration/ModelAppConnect.tsx
+++ b/src/renderer/registration/ModelAppConnect.tsx
@@ -20,7 +20,7 @@ type ConnectInputs = {
 
 type InvalidServer = {
   isInvalid: boolean;
-  cause: 'failed' | 'flask-ml-version' | null;
+  cause: 'failed' | 'flask-ml-version' | 'app-metadata-not-set' | null;
 };
 
 function ModelAppConnect() {
@@ -91,11 +91,19 @@ function ModelAppConnect() {
     } catch (error) {
       if (
         error instanceof Error &&
-        error.message.includes('404 App metadata route not found')
+        error.message.includes('404 APP_METADATA_SLUG not found on server')
       ) {
         setInvalidServer({
           isInvalid: true,
           cause: 'flask-ml-version',
+        });
+      } else if (
+        error instanceof Error &&
+        error.message.includes('App metadata not set')
+      ) {
+        setInvalidServer({
+          isInvalid: true,
+          cause: 'app-metadata-not-set',
         });
       } else {
         setInvalidServer({
@@ -213,8 +221,14 @@ function ModelAppConnect() {
           invalidServer.cause === 'flask-ml-version' && (
             <span className="text-red-500 text-xs">
               Failed to connect to the server. Make sure the Flask-ML version
-              installed on the server is &ge; 0.2.5 and that your server has app
-              metadata added to it.
+              installed on the server is &ge; 0.2.5
+            </span>
+          )}
+        {invalidServer.isInvalid &&
+          invalidServer.cause === 'app-metadata-not-set' && (
+            <span className="text-red-500 text-xs">
+              Failed to connect to the server. Make sure that your server has
+              app metadata added to it.
             </span>
           )}
       </div>

--- a/src/shared/dummy_data/set_dummy_mode.ts
+++ b/src/shared/dummy_data/set_dummy_mode.ts
@@ -1,3 +1,3 @@
-const isDummyMode = false;
+const isDummyMode = true;
 
 export default isDummyMode;

--- a/src/shared/dummy_data/set_dummy_mode.ts
+++ b/src/shared/dummy_data/set_dummy_mode.ts
@@ -1,3 +1,3 @@
-const isDummyMode = true;
+const isDummyMode = false;
 
 export default isDummyMode;


### PR DESCRIPTION
When Flask-ML 0.2.5 is installed, but app metadata isn't set

![Screenshot 2024-11-03 at 8 03 46 PM](https://github.com/user-attachments/assets/0926fb16-c468-4e8e-a6d3-8df8a78edb37)
