### PR TITLE
Fill screen for all file previews when not in modal

### DIFF
--- a/src/main/services/register-model-service.ts
+++ b/src/main/services/register-model-service.ts
@@ -4,10 +4,7 @@ import {
   AppMetadata,
   SchemaAPIRoute,
 } from 'src/shared/generated_models';
-import {
-  isrModelRoutes,
-  sbfAppMetadata,
-} from 'src/main/database/dummy_data/mlmodels';
+import { isrModelRoutes } from 'src/main/database/dummy_data/mlmodels';
 import log from 'electron-log/main';
 import isDummyMode from 'src/shared/dummy_data/set_dummy_mode';
 import MLModelDb from '../models/ml-model';

--- a/src/renderer/components/PreviewFileResponse.tsx
+++ b/src/renderer/components/PreviewFileResponse.tsx
@@ -58,7 +58,7 @@ export default function PreviewFileResponse({
             )}
           </DialogHeader>
           <div className="overflow-auto h-full">
-            <FilePreview response={response} />
+            <FilePreview response={response} modal />
           </div>
         </DialogContent>
       </Dialog>

--- a/src/renderer/components/response_body/file_views/FileView.tsx
+++ b/src/renderer/components/response_body/file_views/FileView.tsx
@@ -59,7 +59,7 @@ export default function FileView({ response }: { response: FileResponse }) {
         </div>
       </div>
       <div className="flex flex-col gap-2 text-md rounded-md">
-        <FilePreview response={response} />
+        <FilePreview response={response} modal={false} />
       </div>
     </div>
   );

--- a/src/renderer/components/response_body/previews/CSVPreview.tsx
+++ b/src/renderer/components/response_body/previews/CSVPreview.tsx
@@ -19,7 +19,13 @@ import {
 } from '@shadcn/select';
 import LoadingScreen from '../../LoadingScreen';
 
-export default function CSVPreview({ filePath }: { filePath: string }) {
+export default function CSVPreview({
+  filePath,
+  modal,
+}: {
+  filePath: string;
+  modal: boolean;
+}) {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchColumn, setSearchColumn] = useState('All Columns');
 
@@ -76,7 +82,9 @@ export default function CSVPreview({ filePath }: { filePath: string }) {
         />
       </div>
       <div className="border border-gray-300 rounded-lg p-4 bg-white">
-        <div className="overflow-auto h-80 pr-2">
+        <div
+          className={`overflow-auto ${modal ? 'max-h-80' : 'max-h-full'} pr-2`}
+        >
           <Table className="min-w-full divide-y divide-gray-200">
             <TableHeader className="bg-gray-50">
               <TableRow>

--- a/src/renderer/components/response_body/previews/FilePreview.tsx
+++ b/src/renderer/components/response_body/previews/FilePreview.tsx
@@ -8,13 +8,25 @@ import MarkdownPreview from './MarkdownPreview';
 import TextPreview from './TextPreview';
 import VideoPreview from './VideoPreview';
 
-export default function FilePreview({ response }: { response: FileResponse }) {
+export default function FilePreview({
+  response,
+  modal,
+}: {
+  response: FileResponse;
+  modal: boolean;
+}) {
   const filePrefixedPath = `file://${response.path}`;
 
   return match(response)
-    .with({ file_type: 'text' }, () => <TextPreview filePath={response.path} />)
-    .with({ file_type: 'json' }, () => <JSONPreview filePath={response.path} />)
-    .with({ file_type: 'csv' }, () => <CSVPreview filePath={response.path} />)
+    .with({ file_type: 'text' }, () => (
+      <TextPreview filePath={response.path} modal={modal} />
+    ))
+    .with({ file_type: 'json' }, () => (
+      <JSONPreview filePath={response.path} modal={modal} />
+    ))
+    .with({ file_type: 'csv' }, () => (
+      <CSVPreview filePath={response.path} modal={modal} />
+    ))
     .with({ file_type: 'img' }, () => (
       <ImagePreview filePath={filePrefixedPath} />
     ))
@@ -25,7 +37,7 @@ export default function FilePreview({ response }: { response: FileResponse }) {
       <VideoPreview filePath={filePrefixedPath} />
     ))
     .with({ file_type: 'markdown' }, () => (
-      <MarkdownPreview filePath={response.path} />
+      <MarkdownPreview filePath={response.path} modal={modal} />
     ))
     .exhaustive();
 }

--- a/src/renderer/components/response_body/previews/JSONPreview.tsx
+++ b/src/renderer/components/response_body/previews/JSONPreview.tsx
@@ -3,7 +3,13 @@ import SyntaxHighlighter from 'react-syntax-highlighter';
 import { github } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import LoadingScreen from '../../LoadingScreen';
 
-export default function JSONPreview({ filePath }: { filePath: string }) {
+export default function JSONPreview({
+  filePath,
+  modal,
+}: {
+  filePath: string;
+  modal: boolean;
+}) {
   const {
     data: fileContents,
     error: fileContentsError,
@@ -19,7 +25,9 @@ export default function JSONPreview({ filePath }: { filePath: string }) {
 
   return (
     <div className="border border-gray-300 rounded-lg p-4 bg-[#f8f8f8]">
-      <div className="overflow-auto max-h-96 px-2">
+      <div
+        className={`overflow-auto ${modal ? 'max-h-80' : 'max-h-full'} pr-2`}
+      >
         <SyntaxHighlighter style={github} language="json">
           {fileContents}
         </SyntaxHighlighter>

--- a/src/renderer/components/response_body/previews/MarkdownPreview.tsx
+++ b/src/renderer/components/response_body/previews/MarkdownPreview.tsx
@@ -4,7 +4,13 @@ import remarkGfm from 'remark-gfm';
 import { useReadFile } from 'src/renderer/lib/hooks';
 import LoadingScreen from '../../LoadingScreen';
 
-export default function MarkdownPreview({ filePath }: { filePath: string }) {
+export default function MarkdownPreview({
+  filePath,
+  modal,
+}: {
+  filePath: string;
+  modal: boolean;
+}) {
   const {
     data: fileContents,
     error: fileContentsError,
@@ -23,7 +29,9 @@ export default function MarkdownPreview({ filePath }: { filePath: string }) {
 
   return (
     <div className="prose max-w-full markdown border border-gray-300 rounded-lg p-4 bg-white">
-      <div className="overflow-auto max-h-96 px-2">
+      <div
+        className={`overflow-auto ${modal ? 'max-h-80' : 'max-h-full'} pr-2`}
+      >
         <Markdown
           rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
           className="text-black"

--- a/src/renderer/components/response_body/previews/TextPreview.tsx
+++ b/src/renderer/components/response_body/previews/TextPreview.tsx
@@ -1,7 +1,13 @@
 import { useReadFile } from 'src/renderer/lib/hooks';
 import LoadingScreen from '../../LoadingScreen';
 
-export default function TextPreview({ filePath }: { filePath: string }) {
+export default function TextPreview({
+  filePath,
+  modal,
+}: {
+  filePath: string;
+  modal: boolean;
+}) {
   const {
     data: fileContents,
     error: fileContentsError,
@@ -20,7 +26,9 @@ export default function TextPreview({ filePath }: { filePath: string }) {
 
   return (
     <div className="max-w-full border border-gray-300 rounded-lg p-4 bg-white">
-      <div className="overflow-auto max-h-96 px-2 whitespace-pre-wrap">
+      <div
+        className={`overflow-auto ${modal ? 'max-h-80' : 'max-h-full'} pr-2 whitespace-pre-wrap`}
+      >
         {fileContents}
       </div>
     </div>


### PR DESCRIPTION
Closes #318 

Views look the same as screenshots in [this PR](https://github.com/UMass-Rescue/RescueBox-Desktop/pull/292) since I don't have a monitor to check with, but they should take up the full screen now. One of you can check just to make sure.